### PR TITLE
remove 'approve' inputs from function signature

### DIFF
--- a/src/protectionmarketlist.schema.json
+++ b/src/protectionmarketlist.schema.json
@@ -127,7 +127,7 @@
           "pattern": "^0x[a-fA-F0-9]{40}$"
         },
         "signature": {
-          "enum": ["function invest(uint256[] amounts, uint256[] approve)"],
+          "enum": ["function invest(uint256[] amounts)"],
           "type": "string"
         }
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,13 +32,9 @@ export interface Tags {
 // would be [ETH, WBTC, USDT]. When calling `invest` on `address`, amounts[0] would correspond to the amount of ETH
 // to invest, amounts[1] would correspond to the amount of WBTC to invest, etc. An amount of MAX_UINT256 should be
 // used to signal that you want to invest all tokens you have
-//
-// The same concept also applies to `approves`, which defines whether or not to check and execute approvals for the
-// given token. This is an option to save gas. Similar to `amounts`, the number passed in here specifies how much
-// to approve the spending contract for
 export interface InvestScript {
   readonly address: string;
-  readonly signature?: 'function invest(uint256[] amounts, uint256[] approve)';
+  readonly signature?: 'function invest(uint256[] amounts)';
 }
 
 // Parameters for exiting a protected investment.

--- a/test/schema/example.protectionmarketlist.json
+++ b/test/schema/example.protectionmarketlist.json
@@ -38,7 +38,7 @@
       "investmentOpportunity": {
         "invest": {
           "address": "0x0000000000000000000000000000000000000000",
-          "signature": "function invest(uint256[] amounts, uint256[] approve)"
+          "signature": "function invest(uint256[] amounts)"
         },
         "divest": {
           "address": "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
Discussion with more context around why we wanted to remove approves is here:
https://github.com/Cozy-Finance/cozy-invest-contracts/pull/4#discussion_r715011767