### PR TITLE
feat: update function signatures for more flexibility

### DIFF
--- a/src/protectionmarketlist.schema.json
+++ b/src/protectionmarketlist.schema.json
@@ -110,11 +110,13 @@
         },
         "signature": {
           "enum": [
-            "function divest(address recipient, uint256[] receiptAmounts, uint256[] rewardAmounts) external payable"
+            "function divest(address recipient, uint256[] calldata receiptAmounts, uint256[] calldata rewardAmounts) external payable",
+            "function divest(address recipient, uint256[] calldata receiptAmounts, uint256[] calldata rewardAmounts, bytes calldata data) external payable"
           ],
           "type": "string"
         }
-      }
+      },
+      "required": ["address", "signature"]
     },
     "InvestScript": {
       "type": "object",
@@ -127,10 +129,14 @@
           "pattern": "^0x[a-fA-F0-9]{40}$"
         },
         "signature": {
-          "enum": ["function invest(uint256[] amounts) external"],
+          "enum": [
+            "function invest(uint256[] calldata amounts) external payable",
+            "function invest(uint256[] calldata amounts, bytes calldata data) external payable"
+          ],
           "type": "string"
         }
-      }
+      },
+      "required": ["address", "signature"]
     },
     "InvestmentOpportunity": {
       "type": "object",

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,9 @@ export interface Tags {
 // used to signal that you want to invest all tokens you have
 export interface InvestScript {
   readonly address: string;
-  readonly signature?: 'function invest(uint256[] amounts) external';
+  readonly signature:
+    | 'function invest(uint256[] calldata amounts) external payable'
+    | 'function invest(uint256[] calldata amounts, bytes calldata data) external payable';
 }
 
 // Parameters for exiting a protected investment.
@@ -45,7 +47,9 @@ export interface InvestScript {
 // tokens and reward tokens should be sent to
 export interface DivestScript {
   readonly address: string;
-  readonly signature?: 'function divest(address recipient, uint256[] receiptAmounts, uint256[] rewardAmounts) external payable';
+  readonly signature:
+    | 'function divest(address recipient, uint256[] calldata receiptAmounts, uint256[] calldata rewardAmounts) external payable'
+    | 'function divest(address recipient, uint256[] calldata receiptAmounts, uint256[] calldata rewardAmounts, bytes calldata data) external payable';
 }
 
 export interface StrategyLeg {

--- a/test/schema/example.protectionmarketlist.json
+++ b/test/schema/example.protectionmarketlist.json
@@ -38,11 +38,11 @@
       "investmentOpportunity": {
         "invest": {
           "address": "0x0000000000000000000000000000000000000000",
-          "signature": "function invest(uint256[] amounts) external"
+          "signature": "function invest(uint256[] calldata amounts, bytes calldata data) external payable"
         },
         "divest": {
           "address": "0x0000000000000000000000000000000000000000",
-          "signature": "function divest(address recipient, uint256[] receiptAmounts, uint256[] rewardAmounts) external payable"
+          "signature": "function divest(address recipient, uint256[] calldata receiptAmounts, uint256[] calldata rewardAmounts, bytes calldata data) external payable"
         },
         "dataURI": "https://api.cozy.finance/opportunities/usdc-yearn",
         "tokens": {


### PR DESCRIPTION
There are now two possible function signatures for both the `invest` and `divest` methods, and because of that the `signature` field is now required 